### PR TITLE
Add form-factor to metadata

### DIFF
--- a/chat.quadrix.Quadrix.desktop
+++ b/chat.quadrix.Quadrix.desktop
@@ -8,3 +8,4 @@ StartupWMClass=quadrix
 Comment=Minimal, simple, multi-platform chat client for the Matrix protocol
 Categories=Network;InstantMessaging;Chat;VideoConference;
 Keywords=matrix;matrix.org;chat;communications;quadrix;
+X-Purism-FormFactor=Workstation;Mobile;

--- a/chat.quadrix.Quadrix.metainfo.xml
+++ b/chat.quadrix.Quadrix.metainfo.xml
@@ -54,4 +54,8 @@
       <display_length compare="lt">xlarge</display_length>
       <display_length compare="gt">xsmall</display_length>
     </requires>
+    <custom>
+      <value key="Purism::form_factor">workstation</value>
+      <value key="Purism::form_factor">mobile</value>
+    </custom>
 </component>


### PR DESCRIPTION
Without this, Quadrix isn't shown in the default Phosh app drawer which doesn't display apps that are not tagged as "mobile-friendly" and also not in the PureOS store as it seems. And since Quadrix is, I think adding that line is appropriate :)

References: [Purism](https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/), [linmob.net](https://linmob.net/phosh-0-12-app-drawer/)